### PR TITLE
Release 0.3.1

### DIFF
--- a/src/.idea/.idea.AutoSpex/.idea/dataSources.xml
+++ b/src/.idea/.idea.AutoSpex/.idea/dataSources.xml
@@ -35,7 +35,7 @@
       <driver-ref>sqlite.xerial</driver-ref>
       <synchronize>true</synchronize>
       <jdbc-driver>org.sqlite.JDBC</jdbc-driver>
-      <jdbc-url>jdbc:sqlite:$PROJECT_DIR$/../tests/AutoSpex.Persistence.Tests/bin/Debug/net8.0/spex.db</jdbc-url>
+      <jdbc-url>jdbc:sqlite:$PROJECT_DIR$/../tests/AutoSpex.Persistence.Tests/bin/Debug/spex.db</jdbc-url>
       <jdbc-additional-properties>
         <property name="com.intellij.clouds.kubernetes.db.enabled" value="false" />
       </jdbc-additional-properties>

--- a/src/AutoSpex.Client/Components/Entries/SpecEntry.axaml
+++ b/src/AutoSpex.Client/Components/Entries/SpecEntry.axaml
@@ -89,7 +89,8 @@
                             BorderThickness="0" CornerRadius="0"
                             VerticalContentAlignment="Center"
                             FontSize="{a:ThemeResource DefaultFontSizeSmall}"
-                            FontFamily="{a:ThemeResource CodeFontFamily}">
+                            FontFamily="{a:ThemeResource CodeFontFamily}"
+                            Padding="10 11 10 10">
                             <TextBox.Styles>
                                 <Style Selector="TextBox:empty">
                                     <Setter Property="Foreground"
@@ -118,7 +119,7 @@
                                         <ContentControl
                                             Content="{Binding }"
                                             ContentTemplate="{StaticResource FilterEntry}"
-                                            MinWidth="400"/>
+                                            MinWidth="400" />
                                     </Flyout>
                                 </Button.Flyout>
                             </Button>

--- a/src/AutoSpex.Client/Components/Items/ElementListItem.axaml
+++ b/src/AutoSpex.Client/Components/Items/ElementListItem.axaml
@@ -53,6 +53,7 @@
                                 properties:Icon.Theme="{StaticResource IconLineLaunch}"
                                 ToolTip.Tip="Open Element" />
                             <Button
+                                Command="{Binding CopyNameCommand}"
                                 Theme="{StaticResource IconButtonSmall}"
                                 properties:Icon.Theme="{StaticResource IconFilledClone}"
                                 IsVisible="{Binding $parent[ListBoxItem].IsPointerOver}"

--- a/src/AutoSpex.Client/Components/Items/EvaluationListItem.axaml
+++ b/src/AutoSpex.Client/Components/Items/EvaluationListItem.axaml
@@ -5,7 +5,8 @@
                     xmlns:controls="clr-namespace:AutoSpex.Client.Resources.Controls"
                     xmlns:components="clr-namespace:AutoSpex.Client.Components"
                     xmlns:engine="clr-namespace:AutoSpex.Engine;assembly=AutoSpex.Engine"
-                    xmlns:properties="clr-namespace:AutoSpex.Client.Resources.Properties">
+                    xmlns:properties="clr-namespace:AutoSpex.Client.Resources.Properties"
+                    xmlns:system="clr-namespace:System;assembly=System.Runtime">
 
     <Design.PreviewWith>
         <StackPanel Width="700" Height="200">
@@ -65,13 +66,8 @@
                 </Border>
 
                 <TextBlock Text="Expected" />
-
-                <controls:HighlightableTextBlock
-                    Text="{Binding Candidate}"
-                    Foreground="{DynamicResource TypeGroupForegroundBrushText}" />
-
-                <TextBlock
-                    Text="to have" />
+                <controls:HighlightableTextBlock Text="{Binding Candidate}" />
+                <TextBlock Text="to have" />
 
                 <controls:HighlightableTextBlock
                     Text="{Binding Criteria}"
@@ -86,9 +82,9 @@
                         </ItemsPanelTemplate>
                     </ItemsControl.ItemsPanel>
                     <ItemsControl.ItemTemplate>
-                        <DataTemplate x:DataType="observers:ValueObserver">
+                        <DataTemplate x:DataType="system:String">
                             <controls:HighlightableTextBlock
-                                Text="{Binding Text}"
+                                Text="{Binding}"
                                 Foreground="{DynamicResource TypeGroupForegroundBrushText}" />
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
@@ -106,7 +102,7 @@
                         Text="but found" />
 
                     <controls:HighlightableTextBlock
-                        Text="{Binding Actual.Text}"
+                        Text="{Binding Actual}"
                         Foreground="{DynamicResource TypeGroupForegroundBrushText}" />
                 </StackPanel>
 

--- a/src/AutoSpex.Client/Observers/ElementObserver.cs
+++ b/src/AutoSpex.Client/Observers/ElementObserver.cs
@@ -40,7 +40,7 @@ public partial class ElementObserver(LogixElement model) : Observer<LogixElement
         data.Set(nameof(ElementObserver), this);
         await clipboard.SetDataObjectAsync(data);
     }
-    
+
     [RelayCommand]
     private async Task CopyName()
     {
@@ -85,11 +85,8 @@ public partial class ElementObserver(LogixElement model) : Observer<LogixElement
     {
         return Model switch
         {
-            DataTypeMember member => member.Name,
-            Parameter parameter => parameter.Name,
-            Tag tag => tag.TagName,
-            LogixCode code => code.Location,
-            LogixComponent component => component.Name,
+            LogixCode code => code.Scope,
+            LogixComponent component => component.Scope,
             _ => Model.ToString() ?? Model.L5XType
         };
     }
@@ -108,7 +105,7 @@ public partial class ElementObserver(LogixElement model) : Observer<LogixElement
 
     private string? DetermineContainer()
     {
-        return Model is LogixObject element ? element.Container : default;
+        return Model is LogixScoped element ? element.Scope.Container : default;
     }
 
     private IEnumerable<PropertyObserver> GetProperties()

--- a/src/AutoSpex.Client/Observers/ElementObserver.cs
+++ b/src/AutoSpex.Client/Observers/ElementObserver.cs
@@ -46,11 +46,7 @@ public partial class ElementObserver(LogixElement model) : Observer<LogixElement
     {
         var clipboard = Shell.Clipboard;
         if (clipboard is null) return;
-
-        var data = new DataObject();
-        data.Set(nameof(Name), Name);
-
-        await clipboard.SetDataObjectAsync(data);
+        await clipboard.SetTextAsync(Name);
     }
 
     [RelayCommand]
@@ -86,7 +82,7 @@ public partial class ElementObserver(LogixElement model) : Observer<LogixElement
         return Model switch
         {
             LogixCode code => code.Scope,
-            LogixComponent component => component.Scope,
+            LogixComponent component => component.Scope.Name,
             _ => Model.ToString() ?? Model.L5XType
         };
     }

--- a/src/AutoSpex.Client/Observers/EvaluationObserver.cs
+++ b/src/AutoSpex.Client/Observers/EvaluationObserver.cs
@@ -22,10 +22,10 @@ public class EvaluationObserver : Observer<Evaluation>
     }
 
     public ResultState Result => Model.Result;
-    public ValueObserver Candidate => new(Model.Candidate);
+    public string Candidate => Model.Candidate;
     public string Criteria => Model.Criteria;
-    public ObservableCollection<ValueObserver> Expected => new(Model.Expected.Select(x => new ValueObserver(x)));
-    public ValueObserver Actual => new(Model.Actual);
+    public ObservableCollection<string> Expected => new(Model.Expected);
+    public string Actual => Model.Actual;
     public Exception? Error => Model.Error;
 
 
@@ -35,10 +35,10 @@ public class EvaluationObserver : Observer<Evaluation>
         FilterText = filter;
 
         var passes = string.IsNullOrEmpty(filter)
-                     || Candidate.Filter(filter)
+                     || Candidate.Satisfies(filter)
                      || Criteria.Satisfies(filter)
-                     || Expected.Any(x => x.Filter(filter))
-                     || Actual.Filter(filter)
+                     || Expected.Any(x => x.Satisfies(filter))
+                     || Actual.Satisfies(filter)
                      || Error is not null && Error.Message.Satisfies(filter);
 
         return passes;

--- a/src/AutoSpex.Client/Pages/Tabs/SpecsPageModel.cs
+++ b/src/AutoSpex.Client/Pages/Tabs/SpecsPageModel.cs
@@ -57,6 +57,7 @@ public partial class SpecsPageModel(NodeObserver node) : PageViewModel("Specs"),
     {
         if (message.Observer is not NodeObserver observer) return;
         if (!observer.Model.IsDescendantOf(node)) return;
+        if (observer.Type != NodeType.Spec) return;
         if (Specs.Contains(observer)) return;
         Specs.Add(new NodeObserver(observer));
     }

--- a/src/AutoSpex.Engine/Argument.cs
+++ b/src/AutoSpex.Engine/Argument.cs
@@ -55,6 +55,7 @@ public class Argument : IEquatable<Argument>
             Criterion criterion => criterion,
             IEnumerable<Argument> arguments => arguments.Select(a => a.ResolveAs(type)),
             string text when type is not null && type != typeof(string) => text.TryParse(type),
+            //todo this needs te thought through more I think. We might not want to alwasy convert if we don't have to
             not string when type is not null && type != value?.GetType() && value is IConvertible convertible =>
                 convertible.ToType(type, null),
             _ => value

--- a/src/AutoSpex.Engine/AutoSpex.Engine.csproj
+++ b/src/AutoSpex.Engine/AutoSpex.Engine.csproj
@@ -11,7 +11,7 @@
       <PackageReference Include="Ardalis.SmartEnum" Version="8.0.0" />
       <PackageReference Include="Ardalis.SmartEnum.SystemTextJson" Version="8.0.0" />
       <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
-      <PackageReference Include="L5Sharp" Version="4.1.0" />
+      <PackageReference Include="L5Sharp" Version="4.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/AutoSpex.Engine/AutoSpex.Engine.csproj
+++ b/src/AutoSpex.Engine/AutoSpex.Engine.csproj
@@ -11,7 +11,7 @@
       <PackageReference Include="Ardalis.SmartEnum" Version="8.0.0" />
       <PackageReference Include="Ardalis.SmartEnum.SystemTextJson" Version="8.0.0" />
       <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
-      <PackageReference Include="L5Sharp" Version="3.3.0" />
+      <PackageReference Include="L5Sharp" Version="4.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/AutoSpex.Engine/Evaluation.cs
+++ b/src/AutoSpex.Engine/Evaluation.cs
@@ -17,7 +17,7 @@ public record Evaluation
         Candidate = candidate.ToText();
         Criteria = criterion.GetCriteria();
         Expected = criterion.GetExpected().Select(x => x.ToText());
-        Actual = actual?.ToText();
+        Actual = actual.ToText();
     }
 
     private Evaluation(ResultState result, Criterion criterion, object candidate, Exception exception)
@@ -45,10 +45,10 @@ public record Evaluation
     public Guid CriterionId { get; } = Guid.Empty;
     public Guid SourceId { get; } = Guid.Empty;
     public ResultState Result { get; } = ResultState.None;
-    public string? Candidate { get; } = string.Empty;
+    public string Candidate { get; } = string.Empty;
     public string Criteria { get; } = string.Empty;
     public IEnumerable<string> Expected { get; } = [];
-    public string? Actual { get; }
+    public string Actual { get; } = string.Empty;
     public Exception? Error { get; }
 
 

--- a/src/AutoSpex.Engine/Extensions.cs
+++ b/src/AutoSpex.Engine/Extensions.cs
@@ -69,13 +69,10 @@ public static class Extensions
         return candidate switch
         {
             bool b => b.ToString().ToLowerInvariant(),
-            Tag tag => tag.TagName,
-            DataTypeMember member => member.Name,
-            Parameter parameter => parameter.Name,
-            LogixCode code => code.Location,
-            LogixComponent component => component.Name,
-            LogixEnum enumeration => enumeration.Name,
             string text => text,
+            LogixEnum enumeration => enumeration.Name,
+            LogixCode code => code.Scope,
+            LogixComponent component => component.Scope,
             IEnumerable enumerable =>
                 $"{string.Join(", ", enumerable.GetType().GetGenericArguments().Select(CommonName).ToArray())}s",
             _ => candidate?.ToString() ?? "null"

--- a/src/AutoSpex.Engine/Extensions.cs
+++ b/src/AutoSpex.Engine/Extensions.cs
@@ -69,10 +69,9 @@ public static class Extensions
         return candidate switch
         {
             bool b => b.ToString().ToLowerInvariant(),
-            string text => text,
             LogixEnum enumeration => enumeration.Name,
-            LogixCode code => code.Scope,
-            LogixComponent component => component.Scope,
+            LogixScoped scoped => scoped.Scope,
+            string text => text, // this needs to be before IEnumerable since string is enumerable
             IEnumerable enumerable =>
                 $"{string.Join(", ", enumerable.GetType().GetGenericArguments().Select(CommonName).ToArray())}s",
             _ => candidate?.ToString() ?? "null"

--- a/src/AutoSpex.Engine/Operations/EqualToOperation.cs
+++ b/src/AutoSpex.Engine/Operations/EqualToOperation.cs
@@ -8,12 +8,13 @@ public class EqualToOperation() : BinaryOperation("Equal To")
     {
         //If the input is a logix element we will use the EquivalentTo method to compare the entire XMl tree.
         //This is so that it can support entire LogixElement or LogixData structures.
-        if (input is LogixElement element)
+        //todo I think this actually might need to be split back out but not sure. For now I have to use LogixObject to avoid LogixData elements from using this method
+        if (input is LogixObject element)
         {
             var other = value switch
             {
-                LogixElement e => e,
-                string s => s.TryParse<LogixElement>(),
+                LogixObject e => e,
+                string s => s.TryParse<LogixObject>(),
                 _ => null
             };
 

--- a/src/AutoSpex.Engine/Query.cs
+++ b/src/AutoSpex.Engine/Query.cs
@@ -82,13 +82,13 @@ public partial class Query
         if (Element == Element.Tag)
         {
             //This method gets the nested tag names which is why we treat it differently.
-            var scoped = content.All(LocalName);
-            return string.IsNullOrEmpty(ContainerName) ? scoped : scoped.Where(t => t.Container == ContainerName);
+            var scoped = content.Find<Tag>(LocalName);
+            return string.IsNullOrEmpty(ContainerName) ? scoped : scoped.Where(t => t.Scope.Container == ContainerName);
         }
 
         //Every other component is global, so we can just use the all method and scope the provided container name if configured.
-        var candidates = content.All(new ComponentKey(Element.Name, Name));
-        return string.IsNullOrEmpty(ContainerName) ? candidates : candidates.Where(t => t.Container == ContainerName);
+        var candidates = content.Find($"{Element.Name}/{Name}");
+        return string.IsNullOrEmpty(ContainerName) ? candidates : candidates.Where(t => t.Scope.Container == ContainerName);
     }
 
     /// <summary>

--- a/src/AutoSpex.Engine/Spec.cs
+++ b/src/AutoSpex.Engine/Spec.cs
@@ -184,12 +184,12 @@ public class Spec() : IEquatable<Spec>
             var candidates = elements.Where(FilterElement).ToList();
 
             //3. Verify the candidates elements.
-            var verifications = candidates.Select(VerifyElement);
+            var verifications = candidates.Select(VerifyElement).ToList();
 
             stopwatch.Stop();
 
             //Merge/flatten into single verification object.
-            return Verification.Merge(verifications.ToList(), stopwatch.ElapsedMilliseconds);
+            return Verification.Merge(verifications, stopwatch.ElapsedMilliseconds);
         }
         catch (Exception e)
         {

--- a/src/AutoSpex.Engine/TypeGroup.cs
+++ b/src/AutoSpex.Engine/TypeGroup.cs
@@ -168,7 +168,7 @@ public abstract class TypeGroup : SmartEnum<TypeGroup, int>
             typeof(Revision),
             typeof(L5Sharp.Core.Argument),
             typeof(IPAddress),
-            typeof(ComponentKey)
+            typeof(Scope)
         ];
 
 

--- a/src/AutoSpex.Persistence/ConnectionManager.cs
+++ b/src/AutoSpex.Persistence/ConnectionManager.cs
@@ -5,7 +5,7 @@ namespace AutoSpex.Persistence;
 
 public class ConnectionManager : IConnectionManager
 {
-    private const string AppDatabase = "spex.db";
+    private const string AppDatabase = "../spex.db";
     public static readonly string ConnectionString = BuildConnectionString();
 
     /// <inheritdoc />

--- a/src/AutoSpex.Persistence/Variables/GetScopedVariables.cs
+++ b/src/AutoSpex.Persistence/Variables/GetScopedVariables.cs
@@ -15,17 +15,18 @@ internal class GetScopedVariablesHandler(IConnectionManager manager)
     private const string GetInheritedVariables =
         """
         WITH Tree AS (
-            SELECT NodeId, ParentId
+            SELECT NodeId, ParentId, 0 as [Distance]
             FROM Node
             WHERE NodeId = @NodeId
             UNION ALL
-            SELECT n.NodeId, n.ParentId
+            SELECT n.NodeId, n.ParentId, t.distance + 1 [Distance]
             FROM Node n
                      INNER JOIN Tree t ON t.ParentId = n.NodeId)
 
         SELECT [VariableId], [Name], [Group], [Value]
         FROM Tree t
         JOIN Variable v ON v.NodeId = t.NodeId
+        ORDER BY Distance
         """;
 
     public async Task<IEnumerable<Variable>> Handle(GetScopedVariables request, CancellationToken cancellationToken)

--- a/tests/AutoSpex.Persistence.Tests/TestContext.cs
+++ b/tests/AutoSpex.Persistence.Tests/TestContext.cs
@@ -5,7 +5,7 @@ namespace AutoSpex.Persistence.Tests;
 public sealed class TestContext : IDisposable
 {
     private readonly ServiceProvider _provider;
-    private const string AppDb = "spex.db";
+    private const string AppDb = "../spex.db";
 
     public TestContext()
     {


### PR DESCRIPTION
This pull request includes a variety of changes across multiple files to improve code consistency, simplify logic, and enhance functionality. The most important changes include updates to the database connection strings, UI component adjustments, and modifications to observer logic.

### Database Connection Updates:
* [`src/.idea/.idea.AutoSpex/.idea/dataSources.xml`](diffhunk://#diff-06405118aba1eba4a13a076e049d3f891e0f1f560014be3fbd6f94d956c4072aL38-R38): Updated the `jdbc-url` to remove the `net8.0` directory from the path.
* [`src/AutoSpex.Persistence/ConnectionManager.cs`](diffhunk://#diff-886de313addf0f43d9c22a96a54b6c6c70fd13fa144739338f8701bdc9446964L8-R8): Changed the `AppDatabase` path to `../spex.db` to ensure consistency across environments.
* [`tests/AutoSpex.Persistence.Tests/TestContext.cs`](diffhunk://#diff-2d25d7fcaf2e472bda7d70600fbb78380991ffda84b6931e773a1019f57966a5L8-R8): Updated the `AppDb` path to `../spex.db` for test consistency.

### UI Component Adjustments:
* [`src/AutoSpex.Client/Components/Entries/SpecEntry.axaml`](diffhunk://#diff-7428e57e0cc879a131759ed96e2b4f07f3051d670594d3467a76bff4a7d0df23L92-R93): Added padding to the `TextBox` element for better UI spacing.
* [`src/AutoSpex.Client/Components/Items/ElementListItem.axaml`](diffhunk://#diff-b49bf3c12d07a77bd1d87212ec1d316089e03da53b89c6c8d7f873f8d1312bdfR56): Added a `CopyNameCommand` binding to a button for enhanced functionality.
* [`src/AutoSpex.Client/Components/Items/EvaluationListItem.axaml`](diffhunk://#diff-a202c669adbd7a596a8f7548bbb210f27bf6ee6a92f94043be8a08c1092696b8L68-R70): Various changes to simplify the XAML structure and improve data binding. [[1]](diffhunk://#diff-a202c669adbd7a596a8f7548bbb210f27bf6ee6a92f94043be8a08c1092696b8L68-R70) [[2]](diffhunk://#diff-a202c669adbd7a596a8f7548bbb210f27bf6ee6a92f94043be8a08c1092696b8L89-R87) [[3]](diffhunk://#diff-a202c669adbd7a596a8f7548bbb210f27bf6ee6a92f94043be8a08c1092696b8L109-R105)

### Observer Logic Modifications:
* [`src/AutoSpex.Client/Observers/ElementObserver.cs`](diffhunk://#diff-bd2a405a9aafdbf250dcf0fec4152f730455f4b7abf7750e94db3fcd985567b0L49-R49): Simplified the `CopyName` method to use `SetTextAsync` and updated `DetermineName` and `DetermineContainer` methods for better scope handling. [[1]](diffhunk://#diff-bd2a405a9aafdbf250dcf0fec4152f730455f4b7abf7750e94db3fcd985567b0L49-R49) [[2]](diffhunk://#diff-bd2a405a9aafdbf250dcf0fec4152f730455f4b7abf7750e94db3fcd985567b0L88-R85) [[3]](diffhunk://#diff-bd2a405a9aafdbf250dcf0fec4152f730455f4b7abf7750e94db3fcd985567b0L111-R104)
* [`src/AutoSpex.Client/Observers/EvaluationObserver.cs`](diffhunk://#diff-2735ea6cd83070d143af9a6a63bab09018558ac8a8ede1417e8a48c9e7ecbbf5L25-R28): Changed `Candidate`, `Expected`, and `Actual` properties to use strings and collections of strings instead of custom objects. [[1]](diffhunk://#diff-2735ea6cd83070d143af9a6a63bab09018558ac8a8ede1417e8a48c9e7ecbbf5L25-R28) [[2]](diffhunk://#diff-2735ea6cd83070d143af9a6a63bab09018558ac8a8ede1417e8a48c9e7ecbbf5L38-R41)

### Engine and Query Enhancements:
* [`src/AutoSpex.Engine/AutoSpex.Engine.csproj`](diffhunk://#diff-2f80a0409f2f93deb1474a40b5d7feafe1842da9ed80059522efc63919cd1bd7L14-R14): Upgraded the `L5Sharp` package to version `4.2.0`.
* [`src/AutoSpex.Engine/Query.cs`](diffhunk://#diff-e9fa623559cc74d4287c284c9dcb94aca16177d80c4ab51b259b3db7ad87669dL85-R91): Refined the query logic to use `Find` method and updated scope handling.
* [`src/AutoSpex.Engine/Extensions.cs`](diffhunk://#diff-7c2b6155c0e01b245f191a523d55d7c455435ea657e548c7bfcdf8b3fc79f4a7L72-R74): Adjusted the `ToText` method to handle `LogixScoped` objects.

### Miscellaneous Improvements:
* [`src/AutoSpex.Engine/Evaluation.cs`](diffhunk://#diff-6a3c493694167b4f6dc51c90df3645a81d8253a833f090ad2929b655003e5c1eL20-R20): Ensured `Actual` and `Candidate` properties are non-nullable strings. [[1]](diffhunk://#diff-6a3c493694167b4f6dc51c90df3645a81d8253a833f090ad2929b655003e5c1eL20-R20) [[2]](diffhunk://#diff-6a3c493694167b4f6dc51c90df3645a81d8253a833f090ad2929b655003e5c1eL48-R51)
* [`src/AutoSpex.Engine/Operations/EqualToOperation.cs`](diffhunk://#diff-a0a700eacd8f6a915d21994d7622d41b6c1b05885393836c03bf14744a5f4cb5L11-R17): Modified the evaluation logic to use `LogixObject` instead of `LogixElement`.
* [`src/AutoSpex.Engine/Spec.cs`](diffhunk://#diff-305aa103378f77418fba5846134fad618a2d596151c24b488d2641158f371f4fL187-R192): Optimized the `RunSpec` method to convert verifications to a list earlier.