### PR TITLE
Release 0.6.1

### DIFF
--- a/src/AutoSpex.Client/AutoSpex.Client.csproj
+++ b/src/AutoSpex.Client/AutoSpex.Client.csproj
@@ -34,7 +34,7 @@
         <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.1.0.3"/>
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2"/>
         <PackageReference Include="FluentResults" Version="3.16.0"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2024.2.0"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
         <PackageReference Include="Lamar" Version="13.1.0"/>
         <PackageReference Include="MediatR" Version="12.4.1"/>
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>

--- a/src/AutoSpex.Client/AutoSpex.Client.csproj
+++ b/src/AutoSpex.Client/AutoSpex.Client.csproj
@@ -10,7 +10,7 @@
         <LangVersion>12</LangVersion>
         <ApplicationIcon>Resources\Images\logo.ico</ApplicationIcon>
         <Platforms>AnyCPU;x64;x86</Platforms>
-        <Version>0.6.0</Version>
+        <Version>0.6.1</Version>
         <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     </PropertyGroup>
 

--- a/src/AutoSpex.Client/Resources/Controls/Entry.cs
+++ b/src/AutoSpex.Client/Resources/Controls/Entry.cs
@@ -16,6 +16,8 @@ using Avalonia.Interactivity;
 using Avalonia.Styling;
 using Avalonia.VisualTree;
 
+// ReSharper disable MemberCanBePrivate.Global
+
 namespace AutoSpex.Client.Resources.Controls;
 
 [PseudoClasses(ClassEmpty)]
@@ -70,6 +72,10 @@ public class Entry : TemplatedControl
     public static readonly StyledProperty<bool> UseExpanderProperty =
         AvaloniaProperty.Register<Entry, bool>(
             nameof(UseExpander));
+
+    public static readonly StyledProperty<int> PopulationDelayProperty =
+        AvaloniaProperty.Register<Entry, int>(
+            nameof(PopulationDelay), defaultValue: 5);
 
     public static readonly StyledProperty<Func<string?, CancellationToken, Task<IEnumerable<object>>>?>
         PopulateProperty =
@@ -171,6 +177,12 @@ public class Entry : TemplatedControl
         set => SetValue(UseExpanderProperty, value);
     }
 
+    public int PopulationDelay
+    {
+        get => GetValue(PopulationDelayProperty);
+        set => SetValue(PopulationDelayProperty, value);
+    }
+
     public Func<string?, CancellationToken, Task<IEnumerable<object>>>? Populate
     {
         get => GetValue(PopulateProperty);
@@ -262,8 +274,7 @@ public class Entry : TemplatedControl
     /// </summary>
     private void OnButtonKeyDown(object? sender, KeyEventArgs e)
     {
-        if (e.Key is Key.Tab || e.KeyModifiers != KeyModifiers.None) return;
-        
+        if (e.Key is not Key.Enter || e.KeyModifiers != KeyModifiers.None) return;
         if (IsDropDownOpen) return;
         IsDropDownOpen = true;
         e.Handled = true;
@@ -442,8 +453,7 @@ public class Entry : TemplatedControl
 
         if (Populate is null) return;
 
-        //todo Could make timeout configurable.
-        var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(PopulationDelay));
 
         try
         {

--- a/src/AutoSpex.Client/Resources/Controls/Entry.cs
+++ b/src/AutoSpex.Client/Resources/Controls/Entry.cs
@@ -262,7 +262,8 @@ public class Entry : TemplatedControl
     /// </summary>
     private void OnButtonKeyDown(object? sender, KeyEventArgs e)
     {
-        if (e.Key is Key.Tab) return;
+        if (e.Key is Key.Tab || e.KeyModifiers != KeyModifiers.None) return;
+        
         if (IsDropDownOpen) return;
         IsDropDownOpen = true;
         e.Handled = true;

--- a/src/AutoSpex.Engine/AutoSpex.Engine.csproj
+++ b/src/AutoSpex.Engine/AutoSpex.Engine.csproj
@@ -10,8 +10,8 @@
     <ItemGroup>
       <PackageReference Include="Ardalis.SmartEnum" Version="8.0.0" />
       <PackageReference Include="Ardalis.SmartEnum.SystemTextJson" Version="8.0.0" />
-      <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
-      <PackageReference Include="L5Sharp" Version="4.2.0" />
+      <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
+      <PackageReference Include="L5Sharp" Version="4.3.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/AutoSpex.Engine/Element.cs
+++ b/src/AutoSpex.Engine/Element.cs
@@ -25,7 +25,6 @@ public abstract class Element : SmartEnum<Element, string>
     private Element(Type type) : base(type.Name, type.Name)
     {
         Type = type ?? throw new ArgumentNullException(nameof(type));
-        _customProperties.Add(This);
     }
 
     private Element(string name, Type type) : base(name, type.FullName ?? throw new ArgumentNullException(nameof(type)))

--- a/src/AutoSpex.Engine/Element.cs
+++ b/src/AutoSpex.Engine/Element.cs
@@ -25,6 +25,7 @@ public abstract class Element : SmartEnum<Element, string>
     private Element(Type type) : base(type.Name, type.Name)
     {
         Type = type ?? throw new ArgumentNullException(nameof(type));
+        _customProperties.Add(This);
     }
 
     private Element(string name, Type type) : base(name, type.FullName ?? throw new ArgumentNullException(nameof(type)))
@@ -132,9 +133,9 @@ public abstract class Element : SmartEnum<Element, string>
     {
         public AddOnInstructionElement() : base(typeof(AddOnInstruction))
         {
-            Register<Controller>("Controller", x => (x as DataType)?.L5X?.Controller);
-            Register<List<LogixComponent>>("Dependencies", x => (x as DataType)?.Dependencies().ToList());
-            Register<List<CrossReference>>("References", x => (x as DataType)?.References().ToList());
+            Register<Controller>("Controller", x => (x as AddOnInstruction)?.L5X?.Controller);
+            Register<List<LogixComponent>>("Dependencies", x => (x as AddOnInstruction)?.Dependencies().ToList());
+            Register<List<CrossReference>>("References", x => (x as AddOnInstruction)?.References().ToList());
         }
     }
 
@@ -143,6 +144,8 @@ public abstract class Element : SmartEnum<Element, string>
         public ModuleElement() : base(typeof(Module))
         {
             Register<Controller>("Controller", x => (x as Module)?.L5X?.Controller);
+            Register<List<LogixComponent>>("Dependencies", x => (x as Module)?.Dependencies().ToList());
+            Register<List<CrossReference>>("References", x => (x as Module)?.References().ToList());
         }
     }
 
@@ -151,6 +154,8 @@ public abstract class Element : SmartEnum<Element, string>
         public TagElement() : base(typeof(Tag))
         {
             Register<Controller>("Controller", x => (x as Tag)?.L5X?.Controller);
+            Register<List<LogixComponent>>("Dependencies", x => (x as Tag)?.Dependencies().ToList());
+            Register<List<CrossReference>>("References", x => (x as Tag)?.References().ToList());
             Register<IList<Tag>>("Members", x => (x as Tag)?.Members().ToList() ?? []);
         }
     }
@@ -160,6 +165,8 @@ public abstract class Element : SmartEnum<Element, string>
         public ProgramElement() : base(typeof(Program))
         {
             Register<Controller>("Controller", x => (x as Program)?.L5X?.Controller);
+            Register<List<LogixComponent>>("Dependencies", x => (x as Program)?.Dependencies().ToList());
+            Register<List<CrossReference>>("References", x => (x as Program)?.References().ToList());
         }
     }
 
@@ -168,6 +175,8 @@ public abstract class Element : SmartEnum<Element, string>
         public RoutineElement() : base(typeof(Routine))
         {
             Register<Controller>("Controller", x => (x as Routine)?.L5X?.Controller);
+            Register<List<LogixComponent>>("Dependencies", x => (x as Routine)?.Dependencies().ToList());
+            Register<List<CrossReference>>("References", x => (x as Routine)?.References().ToList());
         }
     }
 
@@ -176,6 +185,8 @@ public abstract class Element : SmartEnum<Element, string>
         public TaskElement() : base(typeof(Task))
         {
             Register<Controller>("Controller", x => (x as Task)?.L5X?.Controller);
+            Register<List<LogixComponent>>("Dependencies", x => (x as Task)?.Dependencies().ToList());
+            Register<List<CrossReference>>("References", x => (x as Task)?.References().ToList());
         }
     }
 
@@ -269,6 +280,7 @@ public abstract class Element : SmartEnum<Element, string>
     {
         public RungElement() : base(typeof(Rung))
         {
+            Register<List<CrossReference>>("References", x => (x as Rung)?.References().ToList());
             Register<IEnumerable<Instruction>>("Instructions", x => (x as Rung)?.Text.Instructions());
             Register<IEnumerable<TagName>>("Tags", x => (x as Rung)?.Text.Tags());
         }

--- a/src/AutoSpex.Engine/Operations/ContainingOperation.cs
+++ b/src/AutoSpex.Engine/Operations/ContainingOperation.cs
@@ -1,14 +1,18 @@
-﻿namespace AutoSpex.Engine;
+﻿using System.Collections;
+
+namespace AutoSpex.Engine;
 
 public class ContainingOperation() : BinaryOperation("Containing")
 {
     protected override bool Evaluate(object? input, object value)
     {
-        if (string.IsNullOrEmpty(value.ToString()))
-            throw new ArgumentException("Value cannot be null or empty.", nameof(value));
-
-        return input is not null && input.ToString()?.Contains(value.ToString()!) == true;
+        return input switch
+        {
+            string text when value is string segment => text.Contains(segment),
+            IEnumerable enumerable => enumerable.Cast<object>().Contains(value),
+            _ => false
+        };
     }
 
-    protected override bool Supports(TypeGroup group) => group == TypeGroup.Text;
+    protected override bool Supports(TypeGroup group) => group == TypeGroup.Text || group == TypeGroup.Collection;
 }

--- a/src/AutoSpex.Engine/Property.cs
+++ b/src/AutoSpex.Engine/Property.cs
@@ -164,6 +164,9 @@ public class Property : IEquatable<Property>
     /// </remarks>
     public Property GetProperty(string? path)
     {
+        //Allows support for a special self-referencing property, same as is done in .NET.
+        if (path == nameof(This)) return this;
+
         var property = this;
         var properties = Properties.ToList();
 
@@ -417,7 +420,7 @@ public class Property : IEquatable<Property>
             current = current.Parent;
         }
 
-        return path;
+        return !string.IsNullOrEmpty(path) ? path : Name;
     }
 
     /// <summary>

--- a/src/AutoSpex.Engine/TypeGroup.cs
+++ b/src/AutoSpex.Engine/TypeGroup.cs
@@ -114,6 +114,7 @@ public abstract class TypeGroup : SmartEnum<TypeGroup, int>
             typeof(LogixData),
             typeof(AtomicData),
             typeof(Dimensions),
+            typeof(Revision),
             typeof(ProductType),
             typeof(Vendor)
         ];
@@ -158,7 +159,6 @@ public abstract class TypeGroup : SmartEnum<TypeGroup, int>
             typeof(STRING),
             typeof(NeutralText),
             typeof(TagName),
-            typeof(Revision),
             typeof(L5Sharp.Core.Argument),
             typeof(IPAddress),
             typeof(Scope)

--- a/src/AutoSpex.Persistence/AutoSpex.Persistence.csproj
+++ b/src/AutoSpex.Persistence/AutoSpex.Persistence.csproj
@@ -15,7 +15,7 @@
       <PackageReference Include="FluentMigrator.Runner.SQLite" Version="5.0.0" />
       <PackageReference Include="FluentResults" Version="3.16.0" />
       <PackageReference Include="FluentValidation" Version="11.9.2" />
-      <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
+      <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
       <PackageReference Include="MediatR" Version="12.4.1" />
       <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.8" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />

--- a/src/AutoSpex.Persistence/Internals/SqlL5XHandler.cs
+++ b/src/AutoSpex.Persistence/Internals/SqlL5XHandler.cs
@@ -18,13 +18,13 @@ public class SqlL5XHandler : SqlMapper.TypeHandler<L5X>
         parameter.Value = content.Serialize().ToString().Compress();
     }
 
-    public override L5X? Parse(object? value)
+    public override L5X Parse(object? value)
     {
         var data = value?.ToString();
 
         if (string.IsNullOrEmpty(data))
             return L5X.Empty();
 
-        return L5X.Parse(data.Decompress());
+        return L5X.Parse(data.Decompress(), L5XOptions.Index);
     }
 }

--- a/tests/AutoSpex.Engine.Tests/Elements/DataTypeElementTests.cs
+++ b/tests/AutoSpex.Engine.Tests/Elements/DataTypeElementTests.cs
@@ -38,8 +38,8 @@ public class DataTypeElementTests
         var property = element.Property("Name");
 
         property.Should().NotBeNull();
-        property?.Path.Should().Be("Name");
-        property?.Type.Should().Be(typeof(string));
+        property.Path.Should().Be("Name");
+        property.Type.Should().Be(typeof(string));
     }
     
     [Test]
@@ -50,8 +50,8 @@ public class DataTypeElementTests
         var property = element.Property("Description");
 
         property.Should().NotBeNull();
-        property?.Path.Should().Be("Description");
-        property?.Type.Should().Be(typeof(string));
+        property.Path.Should().Be("Description");
+        property.Type.Should().Be(typeof(string));
     }
     
     [Test]
@@ -72,8 +72,8 @@ public class DataTypeElementTests
         var property = element.Property("Class");
 
         property.Should().NotBeNull();
-        property?.Path.Should().Be("Class");
-        property?.Type.Should().Be(typeof(DataTypeClass));
+        property.Path.Should().Be("Class");
+        property.Type.Should().Be(typeof(DataTypeClass));
     }
     
     [Test]
@@ -84,11 +84,11 @@ public class DataTypeElementTests
         var property = element.Property("Members");
 
         property.Should().NotBeNull();
-        property?.Path.Should().Be("Members");
-        property?.Type.Should().Be(typeof(LogixContainer<DataTypeMember>));
-        property?.DisplayName.Should().Be("DataTypeMember[]");
-        property?.Options.Should().BeEmpty();
-        property?.Group.Should().Be(TypeGroup.Collection);
+        property.Path.Should().Be("Members");
+        property.Type.Should().Be(typeof(LogixContainer<DataTypeMember>));
+        property.DisplayName.Should().Be("DataTypeMember[]");
+        property.Options.Should().BeEmpty();
+        property.Group.Should().Be(TypeGroup.Collection);
     }
     
     [Test]
@@ -99,8 +99,8 @@ public class DataTypeElementTests
         var property = element.Property("Scope");
 
         property.Should().NotBeNull();
-        property?.Path.Should().Be("Scope");
-        property?.Type.Should().Be(typeof(Scope));
+        property.Path.Should().Be("Scope");
+        property.Type.Should().Be(typeof(Scope));
     }
 
     [Test]

--- a/tests/AutoSpex.Engine.Tests/Elements/GeneralTests.cs
+++ b/tests/AutoSpex.Engine.Tests/Elements/GeneralTests.cs
@@ -9,12 +9,12 @@ public class GeneralTests
         var element = Element.Controller;
 
         var property = element.Property("RedundancyInfo.KeepTestEditsOnSwitchOver");
-        
+
         property.Should().NotBeNull();
-        property?.Origin.Should().Be(typeof(Controller));
-        property?.Type.Should().Be(typeof(bool));
-        property?.Path.Should().Be("RedundancyInfo.KeepTestEditsOnSwitchOver");
-        property?.Name.Should().Be("KeepTestEditsOnSwitchOver");
+        property.Origin.Should().Be(typeof(Controller));
+        property.Type.Should().Be(typeof(bool));
+        property.Path.Should().Be("RedundancyInfo.KeepTestEditsOnSwitchOver");
+        property.Name.Should().Be("KeepTestEditsOnSwitchOver");
     }
 
 
@@ -27,7 +27,7 @@ public class GeneralTests
 
         result.Should().BeTrue();
     }
-    
+
     [Test]
     public void DifferentObjects_ShouldBeTheSameInstance_JustMakingSureWeAreNotActuallyCreatingNewObjectsEachTime()
     {
@@ -50,21 +50,5 @@ public class GeneralTests
     {
         var result = Element.Components.ToList();
         result.Should().NotBeEmpty();
-    }
-
-    [Test]
-    public void Property_This_ShouldReturnExpected()
-    {
-        var element = Element.Tag;
-
-        var result = element.This;
-
-        result.Should().NotBeNull();
-        result?.Name.Should().Be("This");
-        result?.Path.Should().BeEmpty();
-        result?.Type.Should().Be(typeof(Tag));
-        result?.Group.Should().Be(TypeGroup.Element);
-        result?.Origin.Should().Be(typeof(Tag));
-        result?.Properties.Should().NotBeEmpty();
     }
 }

--- a/tests/AutoSpex.Engine.Tests/Elements/TagElementTests.cs
+++ b/tests/AutoSpex.Engine.Tests/Elements/TagElementTests.cs
@@ -57,14 +57,14 @@ public class TagElementTests
 
         var property = element.Property("Name");
         
-        property?.Origin.Should().Be(typeof(Tag));
-        property?.Type.Should().Be(typeof(string));
-        property?.Name.Should().Be("Name");
-        property?.Path.Should().Be("Name");
-        property?.Group.Should().Be(TypeGroup.Text);
-        property?.DisplayName.Should().Be("string");
-        property?.Options.Should().BeEmpty();
-        property?.Properties.Should().BeEmpty();
+        property.Origin.Should().Be(typeof(Tag));
+        property.Type.Should().Be(typeof(string));
+        property.Name.Should().Be("Name");
+        property.Path.Should().Be("Name");
+        property.Group.Should().Be(TypeGroup.Text);
+        property.DisplayName.Should().Be("string");
+        property.Options.Should().BeEmpty();
+        property.Properties.Should().BeEmpty();
     }
     
     [Test]
@@ -74,14 +74,14 @@ public class TagElementTests
 
         var property = element.Property("Radix.Name");
         
-        property?.Origin.Should().Be(typeof(Tag));
-        property?.Type.Should().Be(typeof(string));
-        property?.Name.Should().Be("Name");
-        property?.Path.Should().Be("Radix.Name");
-        property?.Group.Should().Be(TypeGroup.Text);
-        property?.DisplayName.Should().Be("string");
-        property?.Options.Should().BeEmpty();
-        property?.Properties.Should().BeEmpty();
+        property.Origin.Should().Be(typeof(Tag));
+        property.Type.Should().Be(typeof(string));
+        property.Name.Should().Be("Name");
+        property.Path.Should().Be("Radix.Name");
+        property.Group.Should().Be(TypeGroup.Text);
+        property.DisplayName.Should().Be("string");
+        property.Options.Should().BeEmpty();
+        property.Properties.Should().BeEmpty();
     }
     
     [Test]
@@ -91,13 +91,23 @@ public class TagElementTests
 
         var property = element.Property("Root.Root.Parent");
         
-        property?.Origin.Should().Be(typeof(Tag));
-        property?.Type.Should().Be(typeof(Tag));
-        property?.Name.Should().Be("Parent");
-        property?.Path.Should().Be("Root.Root.Parent");
-        property?.Group.Should().Be(TypeGroup.Element);
-        property?.DisplayName.Should().Be("Tag");
-        property?.Options.Should().BeEmpty();
-        property?.Properties.Should().NotBeEmpty();
+        property.Origin.Should().Be(typeof(Tag));
+        property.Type.Should().Be(typeof(Tag));
+        property.Name.Should().Be("Parent");
+        property.Path.Should().Be("Root.Root.Parent");
+        property.Group.Should().Be(TypeGroup.Element);
+        property.DisplayName.Should().Be("Tag");
+        property.Options.Should().BeEmpty();
+        property.Properties.Should().NotBeEmpty();
+    }
+
+    [Test]
+    public void PropertiesShouldContainThisReference()
+    {
+        var element = Element.Tag;
+
+        var property = element.Properties.FirstOrDefault(p => p.Name == "This");
+
+        property.Should().NotBeNull();
     }
 }

--- a/tests/AutoSpex.Engine.Tests/Elements/TagElementTests.cs
+++ b/tests/AutoSpex.Engine.Tests/Elements/TagElementTests.cs
@@ -22,7 +22,7 @@ public class TagElementTests
 
         result.Should().NotBeNull();
     }
-    
+
     [Test]
     public void This_WhenCalled_ShouldExpectedValues()
     {
@@ -33,13 +33,13 @@ public class TagElementTests
         result.Origin.Should().Be(typeof(Tag));
         result.Type.Should().Be(typeof(Tag));
         result.Name.Should().Be("This");
-        result.Path.Should().BeEmpty();
+        result.Path.Should().Be("This");
         result.Group.Should().Be(TypeGroup.Element);
         result.DisplayName.Should().Be("Tag");
         result.Options.Should().BeEmpty();
         result.Properties.Should().NotBeEmpty();
     }
-    
+
     [Test]
     public void IsComponent_WhenCalled_ShouldBeTrue()
     {
@@ -56,7 +56,7 @@ public class TagElementTests
         var element = Element.Tag;
 
         var property = element.Property("Name");
-        
+
         property.Origin.Should().Be(typeof(Tag));
         property.Type.Should().Be(typeof(string));
         property.Name.Should().Be("Name");
@@ -66,14 +66,14 @@ public class TagElementTests
         property.Options.Should().BeEmpty();
         property.Properties.Should().BeEmpty();
     }
-    
+
     [Test]
     public void Property_NestedEnumProperty_ShouldBeExpected()
     {
         var element = Element.Tag;
 
         var property = element.Property("Radix.Name");
-        
+
         property.Origin.Should().Be(typeof(Tag));
         property.Type.Should().Be(typeof(string));
         property.Name.Should().Be("Name");
@@ -83,14 +83,14 @@ public class TagElementTests
         property.Options.Should().BeEmpty();
         property.Properties.Should().BeEmpty();
     }
-    
+
     [Test]
     public void Property_NestedElementProperty_ShouldBeExpected()
     {
         var element = Element.Tag;
 
         var property = element.Property("Root.Root.Parent");
-        
+
         property.Origin.Should().Be(typeof(Tag));
         property.Type.Should().Be(typeof(Tag));
         property.Name.Should().Be("Parent");
@@ -99,15 +99,5 @@ public class TagElementTests
         property.DisplayName.Should().Be("Tag");
         property.Options.Should().BeEmpty();
         property.Properties.Should().NotBeEmpty();
-    }
-
-    [Test]
-    public void PropertiesShouldContainThisReference()
-    {
-        var element = Element.Tag;
-
-        var property = element.Properties.FirstOrDefault(p => p.Name == "This");
-
-        property.Should().NotBeNull();
     }
 }

--- a/tests/AutoSpex.Engine.Tests/Operations/ContainingOperationTests.cs
+++ b/tests/AutoSpex.Engine.Tests/Operations/ContainingOperationTests.cs
@@ -1,0 +1,92 @@
+﻿namespace AutoSpex.Engine.Tests.Operations;
+
+[TestFixture]
+public class ContainingOperationTests
+{
+    [Test]
+    public void Operator_Any_ShouldNotBeNull()
+    {
+        var operation = Operation.Containing;
+
+        operation.Should().NotBeNull();
+    }
+    
+    [Test]
+    public void Name_WhenCalled_ShouldBeExpected()
+    {
+        var operation = Operation.Containing;
+
+        operation.Name.Should().Be(nameof(Operation.Containing));
+    }
+    
+    [Test]
+    public void Equals_SameOperation_ShouldBeTrue()
+    {
+        var first = Operation.Containing;
+        var second = Operation.Containing;
+        
+        var result = first.Equals(second);
+
+        result.Should().BeTrue();
+    }
+    
+    [Test]
+    public void Execute_StringArgumentDoesNotContain_ShouldBeFalse()
+    {
+        var operation = Operation.Containing;
+
+        var result = operation.Execute("Test", "Another");
+
+        result.Should().BeFalse();
+    }
+    
+    [Test]
+    public void Execute_StringArgumentDoesContain_ShouldBeExpected()
+    {
+        var operation = Operation.Containing;
+
+        var result = operation.Execute("Something", "Some");
+
+        result.Should().BeTrue();
+    }
+
+    [Test]
+    public void Evaluate_CollectionArgDoesContain_ShouldBeTrue()
+    {
+        var items = new List<int> {1, 2, 3, 4, 5};
+        
+        var result = Operation.Containing.Execute(items, 3);
+        
+        result.Should().BeTrue();
+    }
+    
+    [Test]
+    public void Evaluate_CollectionArgDoesNotContain_ShouldBeFalse()
+    {
+        var items = new List<int> {1, 2, 3, 4, 5};
+        
+        var result = Operation.Containing.Execute(items, 6);
+        
+        result.Should().BeFalse();
+    }
+    
+    [Test]
+    public void Evaluate_CollectionStringArgDoesContain_ShouldBeTrue()
+    {
+        var items = new List<string> {"One", "Two", "Three"};
+        
+        var result = Operation.Containing.Execute(items, "Two");
+        
+        result.Should().BeTrue();
+    }
+    
+    [Test]
+    public void Evaluate_CollectionStringArgDoesNotContain_ShouldBeFalse()
+    {
+        var items = new List<string> {"One", "Two", "Three"};
+        
+        var result = Operation.Containing.Execute(items, "Four");
+        
+        result.Should().BeFalse();
+    }
+}

--- a/tests/AutoSpex.Engine.Tests/PackageTests.ShouldBeVerifiedWhenSerialized.verified.txt
+++ b/tests/AutoSpex.Engine.Tests/PackageTests.ShouldBeVerifiedWhenSerialized.verified.txt
@@ -24,6 +24,7 @@
                 Origin: L5Sharp.Core.Tag,
                 Path: Name
               },
+              Negation: Is,
               Operation: Like,
               Argument: {
                 ArgumentId: Guid_6,
@@ -31,8 +32,7 @@
                   Type: System.String,
                   Data: someName
                 }
-              },
-              Negation: Is
+              }
             }
           ],
           Verifications: [
@@ -43,6 +43,7 @@
                 Origin: L5Sharp.Core.Tag,
                 Path: Value
               },
+              Negation: Is,
               Operation: Equal To,
               Argument: {
                 ArgumentId: Guid_8,
@@ -50,8 +51,7 @@
                   Type: System.Int32,
                   Data: 123
                 }
-              },
-              Negation: Is
+              }
             }
           ],
           FilterInclusion: 0,
@@ -74,6 +74,7 @@
                 Origin: L5Sharp.Core.Tag,
                 Path: Name
               },
+              Negation: Is,
               Operation: Containing,
               Argument: {
                 ArgumentId: Guid_12,
@@ -81,8 +82,7 @@
                   Type: System.String,
                   Data: anotherName
                 }
-              },
-              Negation: Is
+              }
             }
           ],
           Verifications: [
@@ -93,6 +93,7 @@
                 Origin: L5Sharp.Core.Tag,
                 Path: Value
               },
+              Negation: Is,
               Operation: Greater Than,
               Argument: {
                 ArgumentId: Guid_14,
@@ -100,8 +101,7 @@
                   Type: System.Int32,
                   Data: 456
                 }
-              },
-              Negation: Is
+              }
             }
           ],
           FilterInclusion: 0,
@@ -124,6 +124,7 @@
                 Origin: L5Sharp.Core.Tag,
                 Path: Name
               },
+              Negation: Is,
               Operation: Equal To,
               Argument: {
                 ArgumentId: Guid_18,
@@ -131,8 +132,7 @@
                   Type: System.String,
                   Data: yetAnotherName
                 }
-              },
-              Negation: Is
+              }
             }
           ],
           Verifications: [
@@ -143,6 +143,7 @@
                 Origin: L5Sharp.Core.Tag,
                 Path: Value
               },
+              Negation: Not,
               Operation: Equal To,
               Argument: {
                 ArgumentId: Guid_20,
@@ -150,8 +151,7 @@
                   Type: System.Int32,
                   Data: 678
                 }
-              },
-              Negation: Not
+              }
             }
           ],
           FilterInclusion: 0,

--- a/tests/AutoSpex.Engine.Tests/PropertyTests.cs
+++ b/tests/AutoSpex.Engine.Tests/PropertyTests.cs
@@ -4,19 +4,33 @@
 public class PropertyTests
 {
     [Test]
-    public void New_ValidPropertyInfo_ShouldNotBeNull()
+    public void New_ValidPropertyFromTag_ShouldNotBeNull()
     {
         var property = new Property("Name", typeof(string), Element.Tag.This);
+
         property.Should().NotBeNull();
     }
-    
+
     [Test]
     public void New_InvalidPropertyInfo_ShouldNotBeNull()
     {
         var property = new Property("Fake", typeof(string), Element.Tag.This);
+
         property.Should().NotBeNull();
     }
-    
+
+    [Test]
+    public void New_ValidPropertyFromString_ShouldhaveExpectedValues()
+    {
+        var property = new Property("Length", typeof(int), Property.This(typeof(string)));
+
+        property.Key.Should().Be("System.String.Length");
+        property.Origin.Should().Be(typeof(string));
+        property.Name.Should().Be("Length");
+        property.Type.Should().Be(typeof(int));
+        property.Path.Should().Be("Length");
+    }
+
     [Test]
     public void New_InvalidPropertyInfo_ShouldhaveExpectedValues()
     {
@@ -83,7 +97,7 @@ public class PropertyTests
         property?.Origin.Should().Be(typeof(Tag));
         property?.Type.Should().Be(typeof(Tag));
     }
-    
+
     [Test]
     public void GetProperty_InvalidProperty_ShouldRetrunUnknown()
     {
@@ -269,17 +283,41 @@ public class PropertyTests
         value.Should().BeOfType<Tag>();
         value.Should().BeEquivalentTo(expected);
     }
+    
+    [Test]
+    public void This_PrimitiveType_ShouldBeExpected()
+    {
+        var property = Property.This(typeof(int));
+
+        property.Key.Should().Be("System.Int32.This");
+        property.Origin.Should().Be(typeof(int));
+        property.Name.Should().Be("This");
+        property.Type.Should().Be(typeof(int));
+        property.Path.Should().Be("This");
+    }
+    
+    [Test]
+    public void This_ComponentType_ShouldBeExpected()
+    {
+        var property = Property.This(typeof(Tag));
+
+        property.Key.Should().Be("L5Sharp.Core.Tag.This");
+        property.Origin.Should().Be(typeof(Tag));
+        property.Name.Should().Be("This");
+        property.Type.Should().Be(typeof(Tag));
+        property.Path.Should().Be("This");
+    }
 
     [Test]
     public void Default_WhenCalled_HasExpectedValues()
     {
         var property = Property.Default;
 
-        property.Key.Should().Be("System.Object");
+        property.Key.Should().Be("System.Object.This");
         property.Origin.Should().Be(typeof(object));
         property.Parent.Should().BeNull();
         property.Name.Should().Be("This");
-        property.Path.Should().BeEmpty();
+        property.Path.Should().Be("This");
         property.DisplayName.Should().Be("Object");
         property.Group.Should().Be(TypeGroup.Default);
         property.Options.Should().BeEmpty();

--- a/tests/AutoSpex.Engine.Tests/PropertyTests.cs
+++ b/tests/AutoSpex.Engine.Tests/PropertyTests.cs
@@ -94,8 +94,8 @@ public class PropertyTests
         var property = Element.Tag.Property("[PRE]");
 
         property.Should().NotBeNull();
-        property?.Origin.Should().Be(typeof(Tag));
-        property?.Type.Should().Be(typeof(Tag));
+        property.Origin.Should().Be(typeof(Tag));
+        property.Type.Should().Be(typeof(Tag));
     }
 
     [Test]
@@ -190,7 +190,7 @@ public class PropertyTests
         var property = Element.Tag.Property("Radix.Name");
         property.Should().NotBeNull();
 
-        var value = property?.GetValue(tag);
+        var value = property.GetValue(tag);
 
         value.Should().Be(Radix.Binary.Name);
     }
@@ -248,7 +248,7 @@ public class PropertyTests
         var instance = new Tag("Test", new TIMER());
         var property = Element.Tag.Property("Members");
 
-        var value = property?.GetValue(instance);
+        var value = property.GetValue(instance);
 
         value.Should().NotBeNull();
         value.Should().BeOfType<List<Tag>>();
@@ -277,13 +277,13 @@ public class PropertyTests
         var expected = instance["PRE"];
         var property = Element.Tag.Property("[PRE]");
 
-        var value = property?.GetValue(instance);
+        var value = property.GetValue(instance);
 
         value.Should().NotBeNull();
         value.Should().BeOfType<Tag>();
         value.Should().BeEquivalentTo(expected);
     }
-    
+
     [Test]
     public void This_PrimitiveType_ShouldBeExpected()
     {
@@ -295,7 +295,7 @@ public class PropertyTests
         property.Type.Should().Be(typeof(int));
         property.Path.Should().Be("This");
     }
-    
+
     [Test]
     public void This_ComponentType_ShouldBeExpected()
     {
@@ -331,11 +331,11 @@ public class PropertyTests
     {
         var property = Element.Tag.Property("Name");
 
-        var graph = property?.TypeGraph;
+        var graph = property.TypeGraph;
 
         graph.Should().NotBeNull();
         graph.Should().HaveCount(2);
-        graph?[0].Should().Be(typeof(Tag));
-        graph?[1].Should().Be(typeof(string));
+        graph[0].Should().Be(typeof(Tag));
+        graph[1].Should().Be(typeof(string));
     }
 }

--- a/tests/AutoSpex.Engine.Tests/PropertyTests.cs
+++ b/tests/AutoSpex.Engine.Tests/PropertyTests.cs
@@ -313,11 +313,11 @@ public class PropertyTests
     {
         var property = Property.Default;
 
-        property.Key.Should().Be("System.Object.This");
+        property.Key.Should().Be("System.Object");
         property.Origin.Should().Be(typeof(object));
         property.Parent.Should().BeNull();
-        property.Name.Should().Be("This");
-        property.Path.Should().Be("This");
+        property.Name.Should().BeEmpty();
+        property.Path.Should().BeEmpty();
         property.DisplayName.Should().Be("Object");
         property.Group.Should().Be(TypeGroup.Default);
         property.Options.Should().BeEmpty();

--- a/tests/AutoSpex.Engine.Tests/SpecTests.Serialize_ConfiguredSpec_ShouldBeVerified.verified.txt
+++ b/tests/AutoSpex.Engine.Tests/SpecTests.Serialize_ConfiguredSpec_ShouldBeVerified.verified.txt
@@ -9,6 +9,7 @@
         Origin: L5Sharp.Core.Tag,
         Path: Name
       },
+      Negation: Is,
       Operation: Containing,
       Argument: {
         ArgumentId: Guid_3,
@@ -16,8 +17,7 @@
           Type: System.String,
           Data: Test
         }
-      },
-      Negation: Is
+      }
     }
   ],
   Verifications: [
@@ -28,12 +28,12 @@
         Origin: L5Sharp.Core.Tag,
         Path: DataType
       },
+      Negation: Not,
       Operation: Null Or Empty,
       Argument: {
         ArgumentId: Guid_5,
         Value: null
-      },
-      Negation: Not
+      }
     }
   ],
   FilterInclusion: 0,


### PR DESCRIPTION
- Added support for collections in the ContainingOperation.cs #49 
- L5X is indexed so we can get references. #44 
- Added more property navigation #46 
- Revision is not numeric not string #42 
- Added Reference properties to Elements #45 
- Added special case This property #47 
- Updated property to return result even for invalid property paths (this made better UI experience).
- Fixed the entry key down #43 
- Other updates essentially fixed #48 